### PR TITLE
Randomize evaluation seeds and sync analyses

### DIFF
--- a/analyze_results.py
+++ b/analyze_results.py
@@ -15,32 +15,38 @@ OUTPUT_FILENAME = "analysis_results.json"
 RESPONSE_COLUMN = "completion"
 
 # Setup logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
 
 def load_tokenizer(tokenizer_name):
     """
     Load the tokenizer for token length calculation.
-    
+
     Returns:
         The loaded tokenizer or None if loading fails.
     """
     logging.info(f"Loading tokenizer from '{tokenizer_name}'...")
     try:
-        tokenizer = AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_name, trust_remote_code=True
+        )
         logging.info("Tokenizer loaded successfully.")
         return tokenizer
     except Exception as e:
         logging.error(f"Failed to load tokenizer: {e}")
         return None
 
+
 def calculate_total_token_length(details_path, tokenizer):
     """
     Calculate the total token length of responses in parquet files.
-    
+
     Args:
         details_path (str): Path to the details directory containing parquet files.
         tokenizer: The HuggingFace tokenizer to use.
-        
+
     Returns:
         dict: Dictionary with total token length and number of samples, or None if processing fails.
     """
@@ -48,65 +54,77 @@ def calculate_total_token_length(details_path, tokenizer):
     if not os.path.exists(details_path) or not os.path.isdir(details_path):
         logging.warning(f"Details directory does not exist: {details_path}")
         return None
-        
+
     # Find all parquet files in the details directory
-    parquet_files = glob.glob(os.path.join(details_path, "**", "*.parquet"), recursive=True)
-    
+    parquet_files = glob.glob(
+        os.path.join(details_path, "**", "*.parquet"), recursive=True
+    )
+
     if not parquet_files:
         logging.warning(f"No parquet files found in {details_path}")
         return None
-    
+
     # Calculate the total token length across all responses
     total_token_length = 0
     num_samples = 0
-    
+
     for file_path in parquet_files:
         try:
             df = pd.read_parquet(file_path)
-            
+
             if RESPONSE_COLUMN not in df.columns:
                 # Try to find the right column for responses
-                possible_columns = ["completion", "predictions", "generated_text", "response"]
+                possible_columns = [
+                    "completion",
+                    "predictions",
+                    "generated_text",
+                    "response",
+                ]
                 for col in possible_columns:
                     if col in df.columns:
-                        logging.info(f"Found response column: {col} instead of {RESPONSE_COLUMN}")
+                        logging.info(
+                            f"Found response column: {col} instead of {RESPONSE_COLUMN}"
+                        )
                         response_column = col
                         break
                 else:
-                    logging.warning(f"Could not find response column in {file_path}. Available columns: {df.columns.tolist()}")
+                    logging.warning(
+                        f"Could not find response column in {file_path}. Available columns: {df.columns.tolist()}"
+                    )
                     continue
             else:
                 response_column = RESPONSE_COLUMN
-            
+
             # Calculate token length for each response and add to total
             for _, row in df.iterrows():
                 response = str(row.get(response_column, ""))
                 tokens = tokenizer.encode(response, add_special_tokens=False)
                 total_token_length += len(tokens)
                 num_samples += 1
-            
+
             logging.info(f"Processed {file_path}: added {num_samples} responses")
-            
+
         except Exception as e:
             logging.error(f"Error processing file {file_path}: {e}")
             continue
-    
+
     if num_samples > 0:
         return {
             "total_token_length": int(total_token_length),
-            "num_samples": num_samples
+            "num_samples": num_samples,
         }
     else:
         logging.warning("No valid responses found to calculate token length")
         return None
 
+
 def extract_accuracy_from_results(results_path):
     """
     Extract the accuracy (extractive_match) from the results JSON file.
-    
+
     Args:
         results_path (str): Path to the results directory.
-        
+
     Returns:
         dict: Dictionary containing accuracy and stderr, or None if extraction fails.
     """
@@ -114,21 +132,23 @@ def extract_accuracy_from_results(results_path):
     if not os.path.exists(results_path) or not os.path.isdir(results_path):
         logging.warning(f"Results directory does not exist: {results_path}")
         return None
-        
+
     # Find the results JSON file
-    results_files = glob.glob(os.path.join(results_path, "**", "results_*.json"), recursive=True)
-    
+    results_files = glob.glob(
+        os.path.join(results_path, "**", "results_*.json"), recursive=True
+    )
+
     if not results_files:
         logging.warning(f"No results files found in {results_path}")
         return None
-    
+
     # Use the most recent results file if there are multiple
     results_file = sorted(results_files)[-1]
-    
+
     try:
-        with open(results_file, 'r') as f:
+        with open(results_file, "r") as f:
             results_data = json.load(f)
-        
+
         # Extract accuracy information
         if "results" in results_data and "all" in results_data["results"]:
             acc = results_data["results"]["all"].get("extractive_match")
@@ -140,72 +160,88 @@ def extract_accuracy_from_results(results_path):
                 if "extractive_match" in value:
                     return {
                         "accuracy": value["extractive_match"],
-                        "stderr": value.get("extractive_match_stderr")
+                        "stderr": value.get("extractive_match_stderr"),
                     }
-            
-            logging.warning(f"Could not find extractive_match in results file {results_file}")
+
+            logging.warning(
+                f"Could not find extractive_match in results file {results_file}"
+            )
             return None
-            
+
     except Exception as e:
         logging.error(f"Error extracting accuracy from {results_file}: {e}")
         return None
 
+
 def process_experiment(exp_path, tokenizer):
     """
     Process a single experiment directory to extract accuracy and token length.
-    
+
     Args:
         exp_path (str): Path to the experiment directory.
         tokenizer: The tokenizer to use for token length calculation.
-        
+
     Returns:
         dict: Dictionary containing experiment results, or None if processing fails.
     """
     # Check if the necessary directories exist (results and details)
     results_path = os.path.join(exp_path, "results")
     details_path = os.path.join(exp_path, "details")
-    
+
     if not os.path.exists(results_path) or not os.path.exists(details_path):
-        logging.info(f"Experiment {os.path.basename(exp_path)} is incomplete (missing results or details directory), skipping...")
+        logging.info(
+            f"Experiment {os.path.basename(exp_path)} is incomplete (missing results or details directory), skipping..."
+        )
         return None
-    
+
     # Check if results file already exists
     output_file = os.path.join(exp_path, OUTPUT_FILENAME)
     if os.path.exists(output_file):
         logging.info(f"Results file already exists for {exp_path}, skipping...")
         try:
-            with open(output_file, 'r') as f:
+            with open(output_file, "r") as f:
                 return json.load(f)
         except:
             logging.warning(f"Existing results file is invalid, will recalculate")
             # Continue with processing
-    
+
     # Extract experiment configuration from directory name
     exp_name = os.path.basename(exp_path)
-    config_parts = exp_name.split('-')
-    
+    config_parts = exp_name.split("-")
+
     # Parse configuration parameters (seed, temperature, top_p, dtype, etc.)
     try:
-        seed = config_parts[0]
+        seed = int(config_parts[0])
         temperature = config_parts[1]
         top_p = config_parts[2]
         dtype = config_parts[3]
-        max_num_seqs = config_parts[4] 
+        max_num_seqs = config_parts[4]
         max_num_batched_tokens = config_parts[5]
         dataset = config_parts[6]
         max_model_length = config_parts[7]
-    except IndexError:
-        seed, temperature, top_p, dtype, max_num_seqs, max_num_batched_tokens, dataset, max_model_length = ("unknown",) * 8
-        logging.warning(f"Could not parse configuration from directory name: {exp_name}")
-    
+    except (IndexError, ValueError):
+        (
+            seed,
+            temperature,
+            top_p,
+            dtype,
+            max_num_seqs,
+            max_num_batched_tokens,
+            dataset,
+            max_model_length,
+        ) = ("unknown",) * 8
+        logging.warning(
+            f"Could not parse configuration from directory name: {exp_name}"
+        )
+
     # Extract accuracy from results
     results_path = os.path.join(exp_path, "results")
     accuracy_data = extract_accuracy_from_results(results_path)
-    
+
     # Calculate total token length
     details_path = os.path.join(exp_path, "details")
     token_length_data = calculate_total_token_length(details_path, tokenizer)
-    
+
     # Compile results
     results = {
         "experiment": exp_name,
@@ -217,32 +253,35 @@ def process_experiment(exp_path, tokenizer):
             "max_num_seqs": max_num_seqs,
             "max_num_batched_tokens": max_num_batched_tokens,
             "dataset": dataset,
-            "max_model_length": max_model_length
+            "max_model_length": max_model_length,
         },
-        "results": {}
+        "results": {},
     }
-    
+
     if accuracy_data:
         results["results"]["accuracy"] = accuracy_data["accuracy"]
-    
+
     if token_length_data is not None:
-        results["results"]["total_token_length"] = token_length_data["total_token_length"]
+        results["results"]["total_token_length"] = token_length_data[
+            "total_token_length"
+        ]
         results["results"]["num_samples"] = token_length_data["num_samples"]
-    
+
     # Save results to file
     try:
-        with open(output_file, 'w') as f:
+        with open(output_file, "w") as f:
             json.dump(results, f, indent=2)
         logging.info(f"Saved results to {output_file}")
     except Exception as e:
         logging.error(f"Error saving results to {output_file}: {e}")
-    
+
     return results
+
 
 def find_experiment_directories(base_dir, model_name_pattern):
     """
     Find all experiment directories for the specified model pattern.
-    
+
     Returns:
         list: List of paths to experiment directories.
     """
@@ -250,18 +289,22 @@ def find_experiment_directories(base_dir, model_name_pattern):
     if not os.path.exists(model_path):
         logging.error(f"Model directory not found: {model_path}")
         return []
-    
+
     # Get all subdirectories (experiment configurations)
-    exp_dirs = [os.path.join(model_path, d) for d in os.listdir(model_path) 
-                if os.path.isdir(os.path.join(model_path, d))]
-    
+    exp_dirs = [
+        os.path.join(model_path, d)
+        for d in os.listdir(model_path)
+        if os.path.isdir(os.path.join(model_path, d))
+    ]
+
     logging.info(f"Found {len(exp_dirs)} experiment directories")
     return exp_dirs
+
 
 def process_all_experiments(base_dir, model_name_pattern, tokenizer_name):
     """
     Process all experiment directories and compile the results.
-    
+
     Returns:
         dict: Dictionary containing all experiment results.
     """
@@ -269,10 +312,10 @@ def process_all_experiments(base_dir, model_name_pattern, tokenizer_name):
     tokenizer = load_tokenizer(tokenizer_name)
     if not tokenizer:
         return None
-    
+
     # Find experiment directories
     exp_dirs = find_experiment_directories(base_dir, model_name_pattern)
-    
+
     # Process each experiment
     all_results = {}
     for exp_dir in tqdm(exp_dirs, desc="Processing experiments"):
@@ -280,36 +323,57 @@ def process_all_experiments(base_dir, model_name_pattern, tokenizer_name):
         results = process_experiment(exp_dir, tokenizer)
         if results:
             all_results[exp_name] = results
-    
+
     # Save aggregated results
-    output_path = os.path.join(base_dir, model_name_pattern, "all_experiments_results.json")
+    output_path = os.path.join(
+        base_dir, model_name_pattern, "all_experiments_results.json"
+    )
     try:
-        with open(output_path, 'w') as f:
+        with open(output_path, "w") as f:
             json.dump(all_results, f, indent=2)
         logging.info(f"Saved aggregated results to {output_path}")
     except Exception as e:
         logging.error(f"Error saving aggregated results: {e}")
-    
+
     return all_results
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Analyze experiment results.')
-    parser.add_argument('--base_dir', type=str, required=True, help='Base directory containing experiment results.')
-    parser.add_argument('--model_name_pattern', type=str, required=True, help='Model name pattern to process.')
-    parser.add_argument('--tokenizer_name', type=str, required=True, help='Tokenizer for calculating token lengths.')
+    parser = argparse.ArgumentParser(description="Analyze experiment results.")
+    parser.add_argument(
+        "--base_dir",
+        type=str,
+        required=True,
+        help="Base directory containing experiment results.",
+    )
+    parser.add_argument(
+        "--model_name_pattern",
+        type=str,
+        required=True,
+        help="Model name pattern to process.",
+    )
+    parser.add_argument(
+        "--tokenizer_name",
+        type=str,
+        required=True,
+        help="Tokenizer for calculating token lengths.",
+    )
     args = parser.parse_args()
 
     logging.info("Starting experiment analysis...")
-    
+
     # Process all experiments
-    all_results = process_all_experiments(args.base_dir, args.model_name_pattern, args.tokenizer_name)
-    
+    all_results = process_all_experiments(
+        args.base_dir, args.model_name_pattern, args.tokenizer_name
+    )
+
     if all_results:
         logging.info(f"Successfully processed {len(all_results)} experiments")
     else:
         logging.error("Failed to process experiments")
-    
+
     logging.info("Analysis complete.")
+
 
 if __name__ == "__main__":
     main()

--- a/analyze_summary.py
+++ b/analyze_summary.py
@@ -7,23 +7,25 @@ import logging
 from collections import defaultdict
 
 # Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
 
-# List of seed values to analyze0, 1, 2, 3, 4, 42, 100, 123, 666, 2023
-SEEDS = [0, 1, 2, 3, 4, 42, 100, 110, 123, 666, 888, 911, 999, 1000, 2025, 2026]
+# Seeds will be discovered automatically from the results
+
 
 def load_results(file_path):
     """
     Load the results from the JSON file.
-    
+
     Args:
         file_path (str): Path to the JSON file containing results.
-        
+
     Returns:
         dict: The loaded JSON data or None if loading fails.
     """
     try:
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             data = json.load(f)
         logging.info(f"Successfully loaded results from {file_path}")
         return data
@@ -31,55 +33,67 @@ def load_results(file_path):
         logging.error(f"Error loading results from {file_path}: {e}")
         return None
 
+
 def compute_mean_and_std(values):
     """
     Compute mean and standard deviation of values.
-    
+
     Args:
         values (list): List of values to analyze.
-        
+
     Returns:
         tuple: (mean, std_dev)
     """
     import numpy as np
+
     mean = np.mean(values)
     std_dev = np.std(values, ddof=1) if len(values) > 1 else 0.0
     return mean, std_dev
 
+
 def analyze_by_seed(data):
     """
     Analyze results by seed, averaging across all configurations for each seed.
-    
+
     Args:
         data (dict): The loaded results data.
-        
+
     Returns:
         dict: A dictionary containing average results for each seed.
     """
     seed_results = {}
-    
-    # Group experiments by seed
-    for seed in SEEDS:
+
+    # Discover all unique seeds from the data
+    seeds = sorted(
+        {
+            str(exp_data["configuration"].get("seed"))
+            for exp_data in data.values()
+            if "seed" in exp_data.get("configuration", {})
+        },
+        key=int,
+    )
+
+    for seed in seeds:
         seed_experiments = []
-        
+
         # Find all experiments with this seed
         for exp_name, exp_data in data.items():
             try:
-                exp_seed = exp_data["configuration"]["seed"]
-                if exp_seed == str(seed):
+                exp_seed = str(exp_data["configuration"]["seed"])
+                if exp_seed == seed:
                     seed_experiments.append(exp_data)
             except KeyError:
                 continue
-                
+
         if not seed_experiments:
             logging.warning(f"No experiments found for seed {seed}")
             continue
-            
+
         # Calculate average results for this seed
         accuracy_values = []
         token_length_values = []
         sample_counts = []
-        
+
         for exp in seed_experiments:
             try:
                 accuracy_values.append(exp["results"]["accuracy"])
@@ -88,13 +102,17 @@ def analyze_by_seed(data):
             except KeyError as e:
                 logging.warning(f"Missing key in experiment: {e}")
                 continue
-                
+
         # Calculate means and standard deviations
         avg_accuracy = np.mean(accuracy_values)
-        std_accuracy = np.std(accuracy_values, ddof=1) if len(accuracy_values) > 1 else 0.0
+        std_accuracy = (
+            np.std(accuracy_values, ddof=1) if len(accuracy_values) > 1 else 0.0
+        )
         avg_token_length = np.mean(token_length_values)
-        std_token_length = np.std(token_length_values, ddof=1) if len(token_length_values) > 1 else 0.0
-        
+        std_token_length = (
+            np.std(token_length_values, ddof=1) if len(token_length_values) > 1 else 0.0
+        )
+
         # Calculate new metrics
         total_tokens_for_seed = np.sum(token_length_values)
         total_samples_for_seed = np.sum(sample_counts)
@@ -105,8 +123,8 @@ def analyze_by_seed(data):
         )
 
         # Store results
-        seed_results[str(seed)] = {
-            "seed": seed,
+        seed_results[seed] = {
+            "seed": int(seed),
             "results": {
                 "accuracy": avg_accuracy,
                 "accuracy_std_dev": std_accuracy,
@@ -114,32 +132,35 @@ def analyze_by_seed(data):
                 "token_length_std_dev": std_token_length,
                 "avg_token_length_per_sample": avg_token_length_per_sample,
                 "num_experiments": len(seed_experiments),
-                "avg_samples": np.mean(sample_counts) if sample_counts else 0
-            }
+                "avg_samples": np.mean(sample_counts) if sample_counts else 0,
+            },
         }
-        
-        logging.info(f"Seed {seed}: Processed {len(seed_experiments)} experiments, " 
-                    f"avg accuracy: {avg_accuracy:.4f}, "
-                    f"avg total token length: {avg_token_length:.2f}")
-    
+
+        logging.info(
+            f"Seed {seed}: Processed {len(seed_experiments)} experiments, "
+            f"avg accuracy: {avg_accuracy:.4f}, "
+            f"avg total token length: {avg_token_length:.2f}"
+        )
+
     return seed_results
+
 
 def analyze_by_config(data):
     """
     Analyze results by configuration, averaging across seeds for each config.
-    
+
     Args:
         data (dict): The loaded results data.
-        
+
     Returns:
         dict: A dictionary containing average results for each configuration.
     """
     # Initialize storage for different configurations
     config_results = {}
-    
+
     # Group experiments by configuration
     config_experiments = defaultdict(list)
-    
+
     for exp_name, exp_data in data.items():
         try:
             # Extract configuration parameters
@@ -150,22 +171,22 @@ def analyze_by_config(data):
             max_num_batched_tokens = exp_data["configuration"]["max_num_batched_tokens"]
             dataset = exp_data["configuration"]["dataset"]
             max_model_length = exp_data["configuration"]["max_model_length"]
-            
+
             # Create a configuration key
             config_key = (
                 f"temp_{temp}_topp_{top_p}_dtype_{dtype}_seqs_{max_num_seqs}_"
                 f"tokens_{max_num_batched_tokens}_dataset_{dataset}_len_{max_model_length}"
             )
-            
+
             config_experiments[config_key].append(exp_data)
         except KeyError:
             continue
-    
+
     # Calculate average results for each configuration
     for config_key, experiments in config_experiments.items():
         if not experiments:
             continue
-            
+
         # Get configuration details from the first experiment
         first_exp = experiments[0]
         temp = first_exp["configuration"]["temperature"]
@@ -175,40 +196,50 @@ def analyze_by_config(data):
         max_num_batched_tokens = first_exp["configuration"]["max_num_batched_tokens"]
         dataset = first_exp["configuration"]["dataset"]
         max_model_length = first_exp["configuration"]["max_model_length"]
-        
+
         # Extract metrics from all experiments with this configuration
         accuracy_values = []
         total_token_length_values = []
         avg_token_length_per_sample_values = []
         sample_counts = []
-        
+
         for exp in experiments:
             try:
                 accuracy_values.append(exp["results"]["accuracy"])
                 total_token_length_values.append(exp["results"]["total_token_length"])
-                
+
                 # Calculate avg token length per sample for each experiment (seed)
                 total_tokens = exp["results"]["total_token_length"]
                 num_samples = exp["results"]["num_samples"]
                 if num_samples > 0:
                     avg_len_per_sample = total_tokens / num_samples
                     avg_token_length_per_sample_values.append(avg_len_per_sample)
-                
+
                 sample_counts.append(num_samples)
             except KeyError as e:
                 logging.warning(f"Missing key in experiment: {e}")
                 continue
-        
+
         # Calculate means and standard deviations
         avg_accuracy = np.mean(accuracy_values)
-        std_accuracy = np.std(accuracy_values, ddof=1) if len(accuracy_values) > 1 else 0.0
+        std_accuracy = (
+            np.std(accuracy_values, ddof=1) if len(accuracy_values) > 1 else 0.0
+        )
         avg_total_token_length = np.mean(total_token_length_values)
-        std_total_token_length = np.std(total_token_length_values, ddof=1) if len(total_token_length_values) > 1 else 0.0
-        
+        std_total_token_length = (
+            np.std(total_token_length_values, ddof=1)
+            if len(total_token_length_values) > 1
+            else 0.0
+        )
+
         # Calculate mean and std for average token length per sample (across seeds)
         avg_token_length_per_sample = np.mean(avg_token_length_per_sample_values)
-        std_token_length_per_sample = np.std(avg_token_length_per_sample_values, ddof=1) if len(avg_token_length_per_sample_values) > 1 else 0.0
-        
+        std_token_length_per_sample = (
+            np.std(avg_token_length_per_sample_values, ddof=1)
+            if len(avg_token_length_per_sample_values) > 1
+            else 0.0
+        )
+
         # Store results
         config_results[config_key] = {
             "configuration": {
@@ -218,7 +249,7 @@ def analyze_by_config(data):
                 "max_num_seqs": max_num_seqs,
                 "max_num_batched_tokens": max_num_batched_tokens,
                 "dataset": dataset,
-                "max_model_length": max_model_length
+                "max_model_length": max_model_length,
             },
             "results": {
                 "accuracy": avg_accuracy,
@@ -228,82 +259,101 @@ def analyze_by_config(data):
                 "avg_token_length_per_sample": avg_token_length_per_sample,
                 "avg_token_length_per_sample_std": std_token_length_per_sample,
                 "num_experiments": len(experiments),
-                "avg_samples": np.mean(sample_counts) if sample_counts else 0
-            }
+                "avg_samples": np.mean(sample_counts) if sample_counts else 0,
+            },
         }
-        
-        logging.info(f"Config temp={temp}, top_p={top_p}, dtype={dtype}: "
-                    f"Processed {len(experiments)} experiments, "
-                    f"avg accuracy: {avg_accuracy:.4f}, "
-                    f"avg total token length: {avg_total_token_length:.2f}")
-    
+
+        logging.info(
+            f"Config temp={temp}, top_p={top_p}, dtype={dtype}: "
+            f"Processed {len(experiments)} experiments, "
+            f"avg accuracy: {avg_accuracy:.4f}, "
+            f"avg total token length: {avg_total_token_length:.2f}"
+        )
+
     return config_results
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Analyze LLM experiment results')
-    
-    parser.add_argument('--results-path', type=str, required=True,
-                        help='Path to the results JSON file')
-    
-    parser.add_argument('--output-path', type=str, required=True,
-                        help='Path to save the analysis results')
-    
+    parser = argparse.ArgumentParser(description="Analyze LLM experiment results")
+
+    parser.add_argument(
+        "--results-path", type=str, required=True, help="Path to the results JSON file"
+    )
+
+    parser.add_argument(
+        "--output-path",
+        type=str,
+        required=True,
+        help="Path to save the analysis results",
+    )
+
     args = parser.parse_args()
-    
+
     # Load results
     data = load_results(args.results_path)
     if data is None:
         return
-    
+
     # Analyze by seed
     seed_results = analyze_by_seed(data)
-    
+
     # Analyze by configuration
     config_results = analyze_by_config(data)
-    
+
     # Compile final results
     final_results = {
         "seed_analysis": seed_results,
         "configuration_analysis": config_results,
     }
-    
+
     # Save results
     try:
         # Create parent directory if it doesn't exist
         os.makedirs(os.path.dirname(args.output_path), exist_ok=True)
-        
-        with open(args.output_path, 'w') as f:
+
+        with open(args.output_path, "w") as f:
             json.dump(final_results, f, indent=2)
         logging.info(f"Successfully saved analysis results to {args.output_path}")
-        
+
         # Also save a more readable CSV for configuration analysis
-        config_df = pd.DataFrame([
-            {
-                "temperature": data["configuration"]["temperature"],
-                "top_p": data["configuration"]["top_p"],
-                "dtype": data["configuration"]["dtype"],
-                "max_num_seqs": data["configuration"]["max_num_seqs"],
-                "max_num_batched_tokens": data["configuration"]["max_num_batched_tokens"],
-                "dataset": data["configuration"]["dataset"],
-                "max_model_length": data["configuration"]["max_model_length"],
-                "accuracy": data["results"]["accuracy"],
-                "accuracy_std_dev": data["results"]["accuracy_std_dev"],
-                "total_token_length": data["results"]["total_token_length"],
-                "total_token_length_std": data["results"]["total_token_length_std"],
-                "avg_token_length_per_sample": data["results"]["avg_token_length_per_sample"],
-                "avg_token_length_per_sample_std": data["results"]["avg_token_length_per_sample_std"],
-                "num_experiments": data["results"]["num_experiments"],
-                "avg_samples": data["results"]["avg_samples"]
-            }
-            for config, data in config_results.items()
-        ])
-        
-        csv_path = os.path.join(os.path.dirname(args.output_path), "config_analysis.csv")
+        config_df = pd.DataFrame(
+            [
+                {
+                    "temperature": data["configuration"]["temperature"],
+                    "top_p": data["configuration"]["top_p"],
+                    "dtype": data["configuration"]["dtype"],
+                    "max_num_seqs": data["configuration"]["max_num_seqs"],
+                    "max_num_batched_tokens": data["configuration"][
+                        "max_num_batched_tokens"
+                    ],
+                    "dataset": data["configuration"]["dataset"],
+                    "max_model_length": data["configuration"]["max_model_length"],
+                    "accuracy": data["results"]["accuracy"],
+                    "accuracy_std_dev": data["results"]["accuracy_std_dev"],
+                    "total_token_length": data["results"]["total_token_length"],
+                    "total_token_length_std": data["results"]["total_token_length_std"],
+                    "avg_token_length_per_sample": data["results"][
+                        "avg_token_length_per_sample"
+                    ],
+                    "avg_token_length_per_sample_std": data["results"][
+                        "avg_token_length_per_sample_std"
+                    ],
+                    "num_experiments": data["results"]["num_experiments"],
+                    "avg_samples": data["results"]["avg_samples"],
+                }
+                for config, data in config_results.items()
+            ]
+        )
+
+        csv_path = os.path.join(
+            os.path.dirname(args.output_path), "config_analysis.csv"
+        )
         config_df.to_csv(csv_path, index=False)
         logging.info(f"Saved configuration analysis CSV to {csv_path}")
-        
+
     except Exception as e:
         logging.error(f"Error saving analysis results: {e}")
+
 
 if __name__ == "__main__":
     main()

--- a/run_all.sh
+++ b/run_all.sh
@@ -75,24 +75,7 @@ cd $LOCAL_DIR
 
 set -x
 
-SEEDS=(
-    0
-    # 1
-    # 2
-    # 3
-    # 4 
-    # 42 
-    # 100
-    # 110
-    # 123
-    # 666
-    # 888
-    # 911
-    # 999
-    # 1000
-    # 2025
-    # 2026 
-)
+NUM_RUNS=1
 
 TASKS=(
     "custom|aime24|0|0"
@@ -103,14 +86,13 @@ TASKS=(
     # "custom|minerva|0|0"
     # "custom|olympiadbench|0|0"
 )
-for SEED in "${SEEDS[@]}"; do
+for ((RUN=1; RUN<=NUM_RUNS; RUN++)); do
 for TASK in "${TASKS[@]}"; do
     python main.py \
         --model $MODEL \
         --task $TASK \
         --temperature $TEMP \
         --top_p $TOP_P \
-        --seed $SEED \
         --output_dir $OUTPUT_DIR \
         --max_new_tokens $MAX_TOKENS \
         --max_model_length $MAX_MODEL_LENGTH \
@@ -122,7 +104,7 @@ for TASK in "${TASKS[@]}"; do
         --max_num_batched_tokens $MAX_NUM_BATCHED_TOKENS \
         --tensor_parallel_size 4 \
         --pipeline_parallel_size 1 \
-        --data_parallel_size 1 
+        --data_parallel_size 1
 done
 done
 


### PR DESCRIPTION
## Summary
- generate a random seed per run when `--seed` is not provided
- remove manual seed handling in helper scripts and run summary tools
- detect seeds automatically when aggregating results
- avoid seed reuse by checking existing run directories

## Testing
- `black main.py analyze_results.py analyze_summary.py`
- `python -m py_compile main.py analyze_results.py analyze_summary.py`
- `bash -n run_all.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a6af4b770483319888a5938088967c