### PR TITLE
feat: include tensor parallel size in run metadata

### DIFF
--- a/analyze_results.py
+++ b/analyze_results.py
@@ -215,21 +215,25 @@ def process_experiment(exp_path, tokenizer):
         temperature = config_parts[1]
         top_p = config_parts[2]
         dtype = config_parts[3]
-        max_num_seqs = config_parts[4]
-        max_num_batched_tokens = config_parts[5]
-        dataset = config_parts[6]
-        max_model_length = config_parts[7]
+        tensor_parallel_size = config_parts[4]
+        max_num_seqs = config_parts[5]
+        max_num_batched_tokens = config_parts[6]
+        dataset = config_parts[7]
+        max_new_tokens = config_parts[8]
+        max_model_length = config_parts[9]
     except (IndexError, ValueError):
         (
             seed,
             temperature,
             top_p,
             dtype,
+            tensor_parallel_size,
             max_num_seqs,
             max_num_batched_tokens,
             dataset,
+            max_new_tokens,
             max_model_length,
-        ) = ("unknown",) * 8
+        ) = ("unknown",) * 10
         logging.warning(
             f"Could not parse configuration from directory name: {exp_name}"
         )
@@ -250,9 +254,11 @@ def process_experiment(exp_path, tokenizer):
             "temperature": temperature,
             "top_p": top_p,
             "dtype": dtype,
+            "tensor_parallel_size": tensor_parallel_size,
             "max_num_seqs": max_num_seqs,
             "max_num_batched_tokens": max_num_batched_tokens,
             "dataset": dataset,
+            "max_new_tokens": max_new_tokens,
             "max_model_length": max_model_length,
         },
         "results": {},

--- a/analyze_summary.py
+++ b/analyze_summary.py
@@ -167,15 +167,17 @@ def analyze_by_config(data):
             temp = exp_data["configuration"]["temperature"]
             top_p = exp_data["configuration"]["top_p"]
             dtype = exp_data["configuration"]["dtype"]
+            tensor_parallel_size = exp_data["configuration"]["tensor_parallel_size"]
             max_num_seqs = exp_data["configuration"]["max_num_seqs"]
             max_num_batched_tokens = exp_data["configuration"]["max_num_batched_tokens"]
             dataset = exp_data["configuration"]["dataset"]
+            max_new_tokens = exp_data["configuration"]["max_new_tokens"]
             max_model_length = exp_data["configuration"]["max_model_length"]
 
             # Create a configuration key
             config_key = (
-                f"temp_{temp}_topp_{top_p}_dtype_{dtype}_seqs_{max_num_seqs}_"
-                f"tokens_{max_num_batched_tokens}_dataset_{dataset}_len_{max_model_length}"
+                f"temp_{temp}_topp_{top_p}_dtype_{dtype}_tp_{tensor_parallel_size}_seqs_{max_num_seqs}_"
+                f"tokens_{max_num_batched_tokens}_dataset_{dataset}_new_{max_new_tokens}_len_{max_model_length}"
             )
 
             config_experiments[config_key].append(exp_data)
@@ -192,9 +194,11 @@ def analyze_by_config(data):
         temp = first_exp["configuration"]["temperature"]
         top_p = first_exp["configuration"]["top_p"]
         dtype = first_exp["configuration"]["dtype"]
+        tensor_parallel_size = first_exp["configuration"]["tensor_parallel_size"]
         max_num_seqs = first_exp["configuration"]["max_num_seqs"]
         max_num_batched_tokens = first_exp["configuration"]["max_num_batched_tokens"]
         dataset = first_exp["configuration"]["dataset"]
+        max_new_tokens = first_exp["configuration"]["max_new_tokens"]
         max_model_length = first_exp["configuration"]["max_model_length"]
 
         # Extract metrics from all experiments with this configuration
@@ -246,9 +250,11 @@ def analyze_by_config(data):
                 "temperature": temp,
                 "top_p": top_p,
                 "dtype": dtype,
+                "tensor_parallel_size": tensor_parallel_size,
                 "max_num_seqs": max_num_seqs,
                 "max_num_batched_tokens": max_num_batched_tokens,
                 "dataset": dataset,
+                "max_new_tokens": max_new_tokens,
                 "max_model_length": max_model_length,
             },
             "results": {
@@ -322,11 +328,15 @@ def main():
                     "temperature": data["configuration"]["temperature"],
                     "top_p": data["configuration"]["top_p"],
                     "dtype": data["configuration"]["dtype"],
+                    "tensor_parallel_size": data["configuration"][
+                        "tensor_parallel_size"
+                    ],
                     "max_num_seqs": data["configuration"]["max_num_seqs"],
                     "max_num_batched_tokens": data["configuration"][
                         "max_num_batched_tokens"
                     ],
                     "dataset": data["configuration"]["dataset"],
+                    "max_new_tokens": data["configuration"]["max_new_tokens"],
                     "max_model_length": data["configuration"]["max_model_length"],
                     "accuracy": data["results"]["accuracy"],
                     "accuracy_std_dev": data["results"]["accuracy_std_dev"],

--- a/main.py
+++ b/main.py
@@ -71,9 +71,12 @@ def main():
 
     # Create a meaningful run name based on parameters
     model_folder_name = args.model.replace("/", "_")
-    run_name = f"{seed}-{args.temperature}-{args.top_p}-{args.dtype}-{args.max_num_seqs}-{args.max_num_batched_tokens}-{args.task.split('|')[1]}-{args.max_new_tokens}"
-    if max_model_length != args.max_new_tokens:
-        run_name += f"-{max_model_length}"
+    run_name = (
+        f"{seed}-{args.temperature}-{args.top_p}-{args.dtype}-"
+        f"{args.tensor_parallel_size}-{args.max_num_seqs}-"
+        f"{args.max_num_batched_tokens}-{args.task.split('|')[1]}-"
+        f"{args.max_new_tokens}-{max_model_length}"
+    )
     if not args.use_chat_template:
         run_name += "-nochat"
 

--- a/run_all.sh
+++ b/run_all.sh
@@ -86,7 +86,8 @@ TASKS=(
     # "custom|minerva|0|0"
     # "custom|olympiadbench|0|0"
 )
-for ((RUN=1; RUN<=NUM_RUNS; RUN++)); do
+for ((RUN=0; RUN<NUM_RUNS; RUN++)); do
+SEED=$((RANDOM % NUM_RUNS))
 for TASK in "${TASKS[@]}"; do
     python main.py \
         --model $MODEL \
@@ -104,7 +105,8 @@ for TASK in "${TASKS[@]}"; do
         --max_num_batched_tokens $MAX_NUM_BATCHED_TOKENS \
         --tensor_parallel_size 4 \
         --pipeline_parallel_size 1 \
-        --data_parallel_size 1
+        --data_parallel_size 1 \
+        --seed $SEED
 done
 done
 


### PR DESCRIPTION
## Summary
- ensure seeds for multiple runs are sampled in the range `[0, NUM_RUNS-1]`
- include `tensor_parallel_size` in run directory names
- propagate new field through result parsing and summary analysis
- record both `max_new_tokens` and `max_model_length` in run directory names and downstream analysis

## Testing
- `bash -n run_all.sh`
- `python -m py_compile main.py analyze_results.py analyze_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7b30c12d88331af9951bf1ef8cd14